### PR TITLE
solved deep copy object, removed indentation errors, second commit

### DIFF
--- a/js-exercises/deep-copy-object/README.md
+++ b/js-exercises/deep-copy-object/README.md
@@ -1,0 +1,9 @@
+# Instructions
+
+Implement a method `deepCopyObject` which returns a deep copy of a given object.
+
+Give an option in the parameter to copy the descriptors as well.
+
+## Restrictions
+
+- Don't use `JSON.parse`, `eval`, or `Function`.

--- a/js-exercises/deep-copy-object/deepCopyObject.js
+++ b/js-exercises/deep-copy-object/deepCopyObject.js
@@ -1,0 +1,17 @@
+const deepCopyObject = (objToCopy, copyDescriptor) => {
+  if (typeof objToCopy !== 'object' || objToCopy === null || objToCopy === undefined) {
+    return objToCopy;
+  }
+  const copiedObject = Object.create(Object.getPrototypeOf(objToCopy));
+  for (const key in objToCopy) {
+    const value = objToCopy[key];
+    if (copyDescriptor) {
+      const descriptor = Object.getOwnPropertyDescriptor(objToCopy, key);
+      Object.defineProperty(copiedObject, key, descriptor);
+    }
+    copiedObject[key] = deepCopyObject(value);
+  }
+  return copiedObject;
+};
+
+export { deepCopyObject };

--- a/js-exercises/deep-copy-object/deepCopyObject.test.js
+++ b/js-exercises/deep-copy-object/deepCopyObject.test.js
@@ -1,0 +1,25 @@
+import { deepCopyObject } from './deepCopyObject';
+
+describe('deepCopyObject', () => {
+  it('returns a deep copy of given object', () => {
+    const myObj = {
+      subObj: {
+        key: 'value',
+      },
+    };
+
+    const yourObj = deepCopyObject(myObj);
+
+    yourObj.subObj.key = 'new value';
+
+    expect(yourObj.subObj.key).toEqual('new value');
+    expect(myObj.subObj.key).toEqual('value');
+  });
+
+  it('returns copy of other data types', () => {
+    expect(deepCopyObject(4)).toEqual(4);
+    expect(deepCopyObject('string!')).toEqual('string!');
+    expect(deepCopyObject(true)).toBe(true);
+    expect(deepCopyObject(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
Solved deep copy object. Required to make deep copy of an object having nested objects. Ensured the copy object to have same prototype as of original object, option provided to copy property descriptors of each property as well so that the copied object can have the same properties, with the same attributes as the original.