### PR TITLE
solution to permutate without repetitions, removed extra spaces

### DIFF
--- a/js-exercises/permutate-without-repetitions/README.md
+++ b/js-exercises/permutate-without-repetitions/README.md
@@ -1,0 +1,5 @@
+## Permutations with repetitions
+
+Number of combinations
+
+n * n * n ... (r times) = n^r

--- a/js-exercises/permutate-without-repetitions/per.js
+++ b/js-exercises/permutate-without-repetitions/per.js
@@ -1,0 +1,22 @@
+/**
+ * @param {*[]} permutationOptions
+ * @return {*[]}
+ */
+
+const result = [];
+
+const permutations = (argArray, arr) => {
+  if (!argArray.length) result.push(arr);
+
+  for (let i = 0; i < argArray.length; i += 1) {
+    const pivotNum = argArray.splice(i, 1)[0];
+    permutations(argArray, arr.concat(pivotNum));
+    argArray.splice(i, 0, pivotNum);
+  }
+};
+function permutateWithoutRepetitions(inputArray) {
+  permutations(inputArray, []);
+  return result;
+}
+
+export { permutateWithoutRepetitions };

--- a/js-exercises/permutate-without-repetitions/permutateWithoutRepetitions.test.js
+++ b/js-exercises/permutate-without-repetitions/permutateWithoutRepetitions.test.js
@@ -1,0 +1,77 @@
+import { permutateWithoutRepetitions } from './permutateWithoutRepetitions';
+
+function factorial(number) {
+  let result = 1;
+
+  for (let i = 2; i <= number; i += 1) {
+    result *= i;
+  }
+
+  return result;
+}
+
+describe('permutateWithoutRepetitions', () => {
+  it('should permutate string', () => {
+    const permutations1 = permutateWithoutRepetitions(['A']);
+    expect(permutations1).toEqual([
+      ['A'],
+    ]);
+
+    const permutations2 = permutateWithoutRepetitions(['A', 'B']);
+    expect(permutations2.length).toBe(2);
+    expect(permutations2).toEqual([
+      ['A', 'B'],
+      ['B', 'A'],
+    ]);
+
+    const permutations6 = permutateWithoutRepetitions(['A', 'A']);
+    expect(permutations6.length).toBe(2);
+    expect(permutations6).toEqual([
+      ['A', 'A'],
+      ['A', 'A'],
+    ]);
+
+    const permutations3 = permutateWithoutRepetitions(['A', 'B', 'C']);
+    expect(permutations3.length).toBe(factorial(3));
+    expect(permutations3).toEqual([
+      ['A', 'B', 'C'],
+      ['B', 'A', 'C'],
+      ['B', 'C', 'A'],
+      ['A', 'C', 'B'],
+      ['C', 'A', 'B'],
+      ['C', 'B', 'A'],
+    ]);
+
+    const permutations4 = permutateWithoutRepetitions(['A', 'B', 'C', 'D']);
+    expect(permutations4.length).toBe(factorial(4));
+    expect(permutations4).toEqual([
+      ['A', 'B', 'C', 'D'],
+      ['B', 'A', 'C', 'D'],
+      ['B', 'C', 'A', 'D'],
+      ['B', 'C', 'D', 'A'],
+      ['A', 'C', 'B', 'D'],
+      ['C', 'A', 'B', 'D'],
+      ['C', 'B', 'A', 'D'],
+      ['C', 'B', 'D', 'A'],
+      ['A', 'C', 'D', 'B'],
+      ['C', 'A', 'D', 'B'],
+      ['C', 'D', 'A', 'B'],
+      ['C', 'D', 'B', 'A'],
+      ['A', 'B', 'D', 'C'],
+      ['B', 'A', 'D', 'C'],
+      ['B', 'D', 'A', 'C'],
+      ['B', 'D', 'C', 'A'],
+      ['A', 'D', 'B', 'C'],
+      ['D', 'A', 'B', 'C'],
+      ['D', 'B', 'A', 'C'],
+      ['D', 'B', 'C', 'A'],
+      ['A', 'D', 'C', 'B'],
+      ['D', 'A', 'C', 'B'],
+      ['D', 'C', 'A', 'B'],
+      ['D', 'C', 'B', 'A'],
+    ]);
+
+    const permutations5 = permutateWithoutRepetitions(['A', 'B', 'C', 'D', 'E', 'F']);
+    expect(permutations5.length).toBe(factorial(6));
+  });
+});


### PR DESCRIPTION
Solved the permutate without repetitions question. Required to work out all the unique combinations possible with given array elements.